### PR TITLE
Simplify header in index.html and index_sv.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,64 +26,66 @@
 <body>
 	<header>
 		<div class="container">
-			<h1 class="header">Hack23</h1>
-			<p class="panel-caption">Open Source Development</p>
-			<a href="https://www.hack23.com/index_sv.html" lang="sv">(Swedish version)</a>
+				<div>
+					<h1 class="header">Hack23</h1>
+					<p class="panel-caption">Open Source Development</p>
+					<a href="https://www.hack23.com/index_sv.html" lang="sv">(Swedish version)</a>
+				</div>
 		</div>
 	</header>
 	<main class="overview-panel-level">
 		<section>
 			<h2 class="panel-caption">Hack23 </h2>
-			<table><caption>About James Pether Sörling</caption>
-				<tr>
-					<th scope="col">
-						<figure>
-							<img src="jamespethersorling150.webp" alt="James Pether Sörling"
-								style="width: 150px; height: 150px; margin-right: 20px;" loading="lazy">
-							<figcaption>About James Pether Sörling</figcaption>
-						</figure>
-					</th>
-					<td>
-						<p>Experienced technology professional with expertise in information security and delivery of
-							secure
-							cloud
-							systems. Strong advocate for transparency in organizations and committed to ensuring the
-							security and
-							reliability of my open source projects through the use of industry best practices such as
-							OpenSSF and
-							CII Best Practices.</p>
-						<p>James Pether Sörling, a security professional and open source contributor, gave a talk at <a
-								href="https://www.youtube.com/watch?v=A_hq2Y03d6I">Javaforum Göteborg</a> where he
-							discussed
-							how to
-							secure your development pipeline with static and dynamic application security tests, as well
-							as
-							software
-							composition analysis using Sonarqube.</p>
-						<p>In addition, Sörling was a guest on the <a
-								href="https://www.youtube.com/watch?v=aYwSd1Wu28Q&ab_channel=Soluble/">Shift Left Like A
-								Boss</a>
-							security podcast, where he discussed open source tools that can make high velocity
-							development
-							more
-							secure. As an open source contributor for cfn-nag, which performs infrastructure as code
-							(IaC)
-							static
-							analysis of AWS CloudFormation, he also wrote an open source module that integrates CFN-nag
-							into
-							SonarQube.</p>
+				<table><caption>About James Pether Sörling</caption>
+					<tr>
+						<th scope="col">
+							<figure>
+								<img src="jamespethersorling150.webp" alt="James Pether Sörling"
+									style="width: 150px; height: 150px; margin-right: 20px;" loading="lazy">
+								<figcaption>About James Pether Sörling</figcaption>
+							</figure>
+						</th>
+						<td>
+							<p>Experienced technology professional with expertise in information security and delivery of
+								secure
+								cloud
+								systems. Strong advocate for transparency in organizations and committed to ensuring the
+								security and
+								reliability of my open source projects through the use of industry best practices such as
+								OpenSSF and
+								CII Best Practices.</p>
+							<p>James Pether Sörling, a security professional and open source contributor, gave a talk at <a
+									href="https://www.youtube.com/watch?v=A_hq2Y03d6I">Javaforum Göteborg</a> where he
+								discussed
+								how to
+								secure your development pipeline with static and dynamic application security tests, as well
+								as
+								software
+								composition analysis using Sonarqube.</p>
+							<p>In addition, Sörling was a guest on the <a
+									href="https://www.youtube.com/watch?v=aYwSd1Wu28Q&ab_channel=Soluble/">Shift Left Like A
+									Boss</a>
+								security podcast, where he discussed open source tools that can make high velocity
+								development
+								more
+								secure. As an open source contributor for cfn-nag, which performs infrastructure as code
+								(IaC)
+								static
+								analysis of AWS CloudFormation, he also wrote an open source module that integrates CFN-nag
+								into
+								SonarQube.</p>
 
-						<ul>
-							<li>Open source developer and founder of <a href="https://hack23.com/">Hack23</a></li>
-							<li>Check out his <a href="https://www.openhub.net/accounts/pether">OpenHub profile</a></li>
-							<li>View his <a href="https://github.com/Hack23/talks">talks on GitHub</a></li>
-							<li>Connect with him on <a href="https://www.linkedin.com/in/jamessorling/">LinkedIn</a>
-							</li>
-							<li>Read his <a href="https://www.hack23.com/blog.html">blog</a></li>
-						</ul>
-					</td>
-				</tr>
-			</table>
+							<ul>
+								<li>Open source developer and founder of <a href="https://hack23.com/">Hack23</a></li>
+								<li>Check out his <a href="https://www.openhub.net/accounts/pether">OpenHub profile</a></li>
+								<li>View his <a href="https://github.com/Hack23/talks">talks on GitHub</a></li>
+								<li>Connect with him on <a href="https://www.linkedin.com/in/jamessorling/">LinkedIn</a>
+								</li>
+								<li>Read his <a href="https://www.hack23.com/blog.html">blog</a></li>
+							</ul>
+						</td>
+					</tr>
+				</table>
 		</section>
 		<section>
 			<h2 class="panel-caption">Press Coverage</h2>

--- a/index_sv.html
+++ b/index_sv.html
@@ -29,9 +29,11 @@
 
 	<header>
 		<div class="container">
-			<h1 class="header">Hack23</h1>
-			<p class="panel-caption">Öppen källkodsutveckling</p>
-			<a href="https://www.hack23.com/index.html" lang="en">(English version)</a>
+				<div>
+					<h1 class="header">Hack23</h1>
+					<p class="panel-caption">Öppen källkodsutveckling</p>
+					<a href="https://www.hack23.com/index.html" lang="en">(English version)</a>
+				</div>
 		</div>
 	</header>
 
@@ -39,42 +41,42 @@
 	<main class="overview-panel-level">
 		<section>
 			<h2 class="panel-caption">Hack23 </h2>
-			<table><caption>Om James Pether Sörling</caption>
-				<tr>
-					<th scope="col">
-						<figure>
-							<img src="jamespethersorling150.webp" alt="James Pether Sörling"
-								style="width: 150px; height: 150px; margin-right: 20px;" loading="lazy">
-							<figcaption>Om James Pether Sörling</figcaption>
-						</figure>
-					</th>
-					<td>
-						<p>Erfaren teknikprofessional med expertis inom informationssäkerhet och leverans av säkra
-							molnsystem. Stark förespråkare för transparens i organisationer och engagerad i att
-							säkerställa säkerheten och tillförlitligheten i mina öppna källkodsprojekt genom användning
-							av branschens bästa metoder som OpenSSF och CII Best Practices.</p>
-						<p>James Pether Sörling, en säkerhetsprofessional och bidragsgivare till öppen källkod, gav ett
-							föredrag på <a href="https://www.youtube.com/watch?v=A_hq2Y03d6I">Javaforum Göteborg</a> där
-							han diskuterade hur man säkrar din utvecklingspipeline med statiska och dynamiska
-							applikationssäkerhetstester, samt mjukvarusammansättningsanalys med Sonarqube.</p>
-						<p>Utöver detta var Sörling gäst på säkerhetspodcasten <a
-								href="https://www.youtube.com/watch?v=aYwSd1Wu28Q&ab_channel=Soluble/">Shift Left Like A
-								Boss</a>, där han diskuterade öppna källkodsverktyg som kan göra höghastighetsutveckling
-							mer säker. Som en bidragsgivare till öppen källkod för cfn-nag, som utför infrastruktur som
-							kod (IaC) statisk analys av AWS CloudFormation, skrev han också en öppen källkodsmodul som
-							integrerar CFN-nag i SonarQube.</p>
+				<table><caption>Om James Pether Sörling</caption>
+					<tr>
+						<th scope="col">
+							<figure>
+								<img src="jamespethersorling150.webp" alt="James Pether Sörling"
+									style="width: 150px; height: 150px; margin-right: 20px;" loading="lazy">
+								<figcaption>Om James Pether Sörling</figcaption>
+							</figure>
+						</th>
+						<td>
+							<p>Erfaren teknikprofessional med expertis inom informationssäkerhet och leverans av säkra
+								molnsystem. Stark förespråkare för transparens i organisationer och engagerad i att
+								säkerställa säkerheten och tillförlitligheten i mina öppna källkodsprojekt genom användning
+								av branschens bästa metoder som OpenSSF och CII Best Practices.</p>
+							<p>James Pether Sörling, en säkerhetsprofessional och bidragsgivare till öppen källkod, gav ett
+								föredrag på <a href="https://www.youtube.com/watch?v=A_hq2Y03d6I">Javaforum Göteborg</a> där
+								han diskuterade hur man säkrar din utvecklingspipeline med statiska och dynamiska
+								applikationssäkerhetstester, samt mjukvarusammansättningsanalys med Sonarqube.</p>
+							<p>Utöver detta var Sörling gäst på säkerhetspodcasten <a
+									href="https://www.youtube.com/watch?v=aYwSd1Wu28Q&ab_channel=Soluble/">Shift Left Like A
+									Boss</a>, där han diskuterade öppna källkodsverktyg som kan göra höghastighetsutveckling
+								mer säker. Som en bidragsgivare till öppen källkod för cfn-nag, som utför infrastruktur som
+								kod (IaC) statisk analys av AWS CloudFormation, skrev han också en öppen källkodsmodul som
+								integrerar CFN-nag i SonarQube.</p>
 
-						<ul>
-							<li>Öppen källkodsutvecklare och grundare av <a href="https://hack23.com/">Hack23</a></li>
-							<li>Kolla in hans <a href="https://www.openhub.net/accounts/pether">OpenHub-profil</a></li>
-							<li>Se hans <a href="https://github.com/Hack23/talks">presentationer på GitHub</a></li>
-							<li>Koppla upp dig med honom på <a
-									href="https://www.linkedin.com/in/jamessorling/">LinkedIn</a></li>
-							<li>Läs hans <a href="https://www.hack23.com/blog.html">blogg</a></li>
-						</ul>
-					</td>
-				</tr>
-			</table>
+							<ul>
+								<li>Öppen källkodsutvecklare och grundare av <a href="https://hack23.com/">Hack23</a></li>
+								<li>Kolla in hans <a href="https://www.openhub.net/accounts/pether">OpenHub-profil</a></li>
+								<li>Se hans <a href="https://github.com/Hack23/talks">presentationer på GitHub</a></li>
+								<li>Koppla upp dig med honom på <a
+										href="https://www.linkedin.com/in/jamessorling/">LinkedIn</a></li>
+								<li>Läs hans <a href="https://www.hack23.com/blog.html">blogg</a></li>
+							</ul>
+						</td>
+					</tr>
+				</table>
 		</section>
 		<section>
 			<h2 class="panel-caption">Press Coverage</h2>


### PR DESCRIPTION
Combine the header elements into a single container in `index.html` and `index_sv.html`.

* **index.html**
  - Combine the `h1` element, `p` element with class `panel-caption`, and `a` element linking to the alternate language version into a single `div` container.

* **index_sv.html**
  - Combine the `h1` element, `p` element with class `panel-caption`, and `a` element linking to the alternate language version into a single `div` container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/homepage/pull/280?shareId=df4b42fe-2771-4e1a-b3de-33b09410d98b).