### PR TITLE
Add CIA Compliance Manager to Current Projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,34 @@
 		<section>
 			<h2 class="panel-caption">Current Projects</h2>
 			<ul>
-				<li></li>
+				<li>
+					<a href="https://github.com/Hack23/cia-compliance-manager/">CIA Compliance Manager</a> - A comprehensive application designed to help organizations assess, implement, and manage security controls across the CIA triad (Confidentiality, Integrity, and Availability). It provides detailed security assessments, cost estimation tools, business impact analysis, and technical implementation guidance to support organizations in achieving their security objectives within budget constraints.
+					<p>
+						Experience the CIA Compliance Manager in action by testing the application here: <a href="https://hack23.github.io/cia-compliance-manager/">CIA Compliance Manager Application</a>. See how it can help you enhance your organization's security posture today!
+					</p>
+					<ul>
+						<li>
+							<a href="https://github.com/Hack23/cia-compliance-manager/raw/master/LICENSE.md">
+								<img src="https://img.shields.io/github/license/Hack23/cia-compliance-manager.svg" alt="License">
+							</a>
+							<a href="https://scorecard.dev/viewer/?uri=github.com/Hack23/cia-compliance-manager">
+								<img src="https://api.securityscorecards.dev/projects/github.com/Hack23/cia-compliance-manager/badge" alt="OpenSSF Scorecard">
+							</a>
+							<a href="https://github.com/Hack23/cia-compliance-manager/actions/workflows/scorecards.yml">
+								<img src="https://github.com/Hack23/cia-compliance-manager/actions/workflows/scorecards.yml/badge.svg?branch=main" alt="Scorecard supply-chain security">
+							</a>
+						</li>
+					</ul>
+					<p>
+						The CIA Compliance Manager offers security assessments at different levels:
+					</p>
+					<ul>
+						<li><strong>Basic</strong> - Minimal investment, low protection, and high risk of downtime or data breaches. Suitable for non-critical or public-facing systems.</li>
+						<li><strong>Moderate</strong> - A balanced approach to cost and protection, good for mid-sized companies that need compliance without overspending on redundant systems.</li>
+						<li><strong>High</strong> - Required for businesses where data integrity, uptime, and confidentiality are critical. High costs, but justified in regulated industries like finance, healthcare, or e-commerce.</li>
+						<li><strong>Very High</strong> - Over-the-top protection and availability designed for mission-critical systems, such as those in defense or high-security finance. Extremely high CAPEX and OPEX.</li>
+					</ul>
+				</li>
 			</ul>
 		</section>
 		<section>


### PR DESCRIPTION
feat(homepage): add CIA Compliance Manager to Current Projects section

- Added detailed description of the CIA Compliance Manager project
- Included link to GitHub repository and test application
- Added project badges (License, OpenSSF Scorecard, Supply-chain security)
- Added security level descriptions (Basic, Moderate, High, Very High)

https://hack23.github.io/cia-compliance-manager/